### PR TITLE
MTM-59784 Fix banned dependency and aligned the rules with Core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -232,6 +232,11 @@
                 <version>3.1.0</version>
             </dependency>
             <dependency>
+                <groupId>jakarta.validation</groupId>
+                <artifactId>jakarta.validation-api</artifactId>
+                <version>2.0.2</version>
+            </dependency>
+            <dependency>
                 <groupId>javax.ws.rs</groupId>
                 <artifactId>javax.ws.rs-api</artifactId>
                 <version>2.1.1</version>
@@ -508,7 +513,13 @@
                                 <banDuplicatePomDependencyVersions />
                                 <bannedDependencies>
                                     <excludes>
+                                        <exclude>com.sun.xml.bind:jaxb-impl</exclude> <!-- moved to: org.glassfish.jaxb:jaxb-runtime -->
                                         <exclude>commons-logging:commons-logging</exclude> <!-- in favor of SLF4j -->
+                                        <exclude>javax.activation:activation</exclude> <!-- moved to: jakarta.activation:jakarta.activation-api -->
+                                        <exclude>javax.el</exclude> <!-- moved to: jakarta.el:jakarta.el-api -->
+                                        <exclude>javax.mail</exclude> <!-- moved to: jakarta.mail:jakarta.mail-api -->
+                                        <exclude>javax.xml.bind:jaxb-api</exclude> <!-- moved to: jakarta.xml.bind:jakarta.xml.bind-api -->
+                                        <exclude>javax.validation:validation-api</exclude> <!-- moved to: jakarta.validation:jakarta.validation-api -->
                                     </excludes>
                                 </bannedDependencies>
                                 <dependencyConvergence />

--- a/pulsar-client/pom.xml
+++ b/pulsar-client/pom.xml
@@ -281,6 +281,16 @@
             <groupId>com.fasterxml.jackson.module</groupId>
             <artifactId>jackson-module-jsonSchema</artifactId>
             <version>${jackson.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.validation</groupId>
+                    <artifactId>validation-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Fixes:
```
Error:  Failed to execute goal org.apache.maven.plugins:maven-enforcer-plugin:3.5.0:enforce (enforce-rules) on project pulsar: 
Error:  Rule 1: org.apache.maven.enforcer.rules.dependency.BannedDependencies failed with message:
Error:  com.nsn.cumulocity.shared-components.messaging:pulsar:jar:1020.459.0-SNAPSHOT
Error:     com.nsn.cumulocity.dependencies.osgi:pulsar-client:jar:2.8.4-1020.434.0
Error:        com.fasterxml.jackson.module:jackson-module-jsonSchema:jar:2.14.1
Error:           javax.validation:validation-api:jar:1.1.0.Final <--- banned via the exclude/include list
```