### PR TITLE
chore(deps): bump avro.version from 1.11.3 to 1.11.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
 
         <!-- COMPILE DEPENDENCIES VERSIONS -->
         <aircompressor.version>0.17</aircompressor.version>
-        <avro.version>1.11.3</avro.version>
+        <avro.version>1.11.4</avro.version>
         <bookkeeper.version>4.14.5</bookkeeper.version>
         <bouncycastle.version>1.70</bouncycastle.version>
         <cometd.version>3.0.10</cometd.version>


### PR DESCRIPTION
CVE-2024-47561: Arbitrary Code Execution when reading Avro Data