### PR TITLE
MTM-61880 Update vulnerable protobuf and aircompressor dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         </unpack.excludes>
 
         <!-- COMPILE DEPENDENCIES VERSIONS -->
-        <aircompressor.version>0.17</aircompressor.version>
+        <aircompressor.version>0.27</aircompressor.version>
         <avro.version>1.11.4</avro.version>
         <bookkeeper.version>4.14.5</bookkeeper.version>
         <bouncycastle.version>1.70</bouncycastle.version>
@@ -74,7 +74,7 @@
         <odata.version>2.0.4</odata.version>
         <okhttp3.version>3.12.12</okhttp3.version>
         <osgi-core.version>7.0.0</osgi-core.version>
-        <protobuf.version>3.19.6</protobuf.version>
+        <protobuf.version>3.25.5</protobuf.version>
         <pulsar-client.version>2.8.4</pulsar-client.version>
         <rs-api.version>2.1.6</rs-api.version>
         <slf4j.version>1.7.30</slf4j.version>


### PR DESCRIPTION
Core follow-up: https://github.com/Cumulocity-IoT/cumulocity-core/pull/3216