### PR TITLE
Revert "chore(deps): bump bookkeeper.version from 4.14.5 to 4.17.1"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <!-- COMPILE DEPENDENCIES VERSIONS -->
         <aircompressor.version>0.27</aircompressor.version>
         <avro.version>1.11.4</avro.version>
-        <bookkeeper.version>4.17.1</bookkeeper.version>
+        <bookkeeper.version>4.14.5</bookkeeper.version> <!-- pulsar-client.version bound -->
         <bouncycastle.version>1.70</bouncycastle.version>
         <cometd.version>3.0.10</cometd.version>
         <commons-beanutils.version>1.9.4</commons-beanutils.version>
@@ -62,7 +62,7 @@
         <commons-lang3.version>3.14.0</commons-lang3.version>
         <gson.version>2.8.9</gson.version>
         <guava.version>32.1.3-jre</guava.version>
-        <hk2.version>2.6.1</hk2.version>
+        <hk2.version>2.6.1</hk2.version> <!-- pulsar-client.version bound -->
         <jackson.version>2.14.1</jackson.version>
         <javassist.version>3.25.0-GA</javassist.version>
         <jaxb.version>2.3.3</jaxb.version>


### PR DESCRIPTION
Reverts Cumulocity-IoT/cumulocity-dependencies#57

```
[ERROR] com.cumulocity.reliable.notification.service.impl.NotificationPulsarPublishServiceFactoryTest.canCreateAndDestroyServiceUsingFactory -- Time elapsed: 0.002 s <<< ERROR!
java.lang.NoClassDefFoundError: Could not initialize class org.apache.pulsar.common.allocator.PulsarByteBufAllocator
	at org.apache.pulsar.client.impl.ConnectionPool.<init>(ConnectionPool.java:95)
	at org.apache.pulsar.client.impl.ConnectionPool.<init>(ConnectionPool.java:75)
	at org.apache.pulsar.client.impl.ConnectionPool.<init>(ConnectionPool.java:70)
	at org.apache.pulsar.client.impl.PulsarClientImpl.<init>(PulsarClientImpl.java:152)
	at org.apache.pulsar.client.impl.PulsarClientImpl.<init>(PulsarClientImpl.java:133)
	at org.apache.pulsar.client.impl.NoReconnectPulsarClientImpl.<init>(NoReconnectPulsarClientImpl.java:14)
	at org.apache.pulsar.client.impl.NoReconnectPulsarClientBuilder.build(NoReconnectPulsarClientBuilder.java:39)
	at com.cumulocity.messaging.pulsar.impl.PulsarPublishServiceImpl.createPulsarClient(PulsarPublishServiceImpl.java:170)
	at com.cumulocity.messaging.pulsar.impl.PulsarPublishServiceImpl.<init>(PulsarPublishServiceImpl.java:73)
	at com.cumulocity.messaging.pulsar.impl.PulsarPublishServiceImpl.<init>(PulsarPublishServiceImpl.java:53)
	at com.cumulocity.reliable.notification.service.NotificationPulsarPublishServiceFactory.createInstance(NotificationPulsarPublishServiceFactory.java:30)
	at com.cumulocity.reliable.notification.service.impl.NotificationPulsarPublishServiceFactoryTest$TestableNotificationPulsarPublishServiceFactory.createInstance(NotificationPulsarPublishServiceFactoryTest.java:27)
	at com.cumulocity.reliable.notification.service.impl.NotificationPulsarPublishServiceFactoryTest.canCreateAndDestroyServiceUsingFactory(NotificationPulsarPublishServiceFactoryTest.java:54)
```