### PR TITLE
Increase Dependabot limit of open PR's for Java

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,7 @@ updates:
       timezone: "Europe/Berlin"
     registries:
       - "c8y-public"
+    open-pull-requests-limit: 20
     reviewers:
       - "Cumulocity-IoT/c8y-data-at-rest"
       - "@Cumulocity-IoT/c8y-data-in-motion"


### PR DESCRIPTION
We have some backlog of easy dependencies to get through and be up to date