### PR TITLE
Feature/mtm 63330 backport new runners to y2025

### DIFF
--- a/.github/runs-on.yml
+++ b/.github/runs-on.yml
@@ -1,0 +1,12 @@
+runners:
+  default:
+    cpu: [2]
+    ram: [8]
+    disk: default
+    family: ["c7", "m7", "r7"]
+    spot: lowest-price
+    ssh: false
+    tags:
+      - 'TeamName:Data at Rest'
+      - 'Environment:GitHub-Runners'
+      - 'Customer:Cumulocity-IoT/cumulocity-dependencies'

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -8,7 +8,9 @@ permissions:
 
 jobs:
   MavenBuild:
-    runs-on: [cumulocity-dependencies]
+    runs-on:
+      - runs-on=${{ github.run_id }}
+      - runner=default
 
     env:
       WORKSPACE: "${{ github.workspace }}"


### PR DESCRIPTION
Caused by:
- https://github.com/Cumulocity-IoT/cumulocity-dependencies/pull/98
- https://github.com/Cumulocity-IoT/cumulocity-dependencies/pull/114