### PR TITLE
chore(deps): downgrade io.netty:netty-bom from 4.2.0.Final to 4.1.121.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <joda-time.version>2.14.0</joda-time.version>
         <json-path.version>2.8.0</json-path.version>
         <kubernetes-client.version>5.9.0</kubernetes-client.version>
-        <netty.version>4.2.0.Final</netty.version>
+        <netty.version>4.1.121.Final</netty.version>
         <odata.version>2.0.11</odata.version>
         <okhttp.version>3.12.12</okhttp.version>
         <protobuf.version>4.31.0</protobuf.version>


### PR DESCRIPTION
Downgrade [io.netty:netty-bom](https://github.com/netty/netty) from 4.2.0.Final to 4.1.121.Final.

Effectively bumps from 4.1.119.Final to 4.1.121.Final - commits viewable in [compare view](https://github.com/netty/netty/compare/netty-4.1.119.Final...netty-4.1.121.Final)

Caused by:
 - https://github.com/Cumulocity-IoT/cumulocity-dependencies/pull/84