### PR TITLE
chore(deps): MTM-63554 bump spring-boot.version from 2.7.18 to 3.0.13

### DIFF
--- a/cometd-java-server/pom.xml
+++ b/cometd-java-server/pom.xml
@@ -149,6 +149,31 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>replace-javax-to-jakarta</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <replace dir="${unpack.source.directory}">
+                                    <include name="**/*.java"/>
+                                    <replacefilter token="javax.servlet" value="jakarta.servlet" />
+                                    <replacefilter token="javax.websocket" value="jakarta.websocket" />
+                                </replace>
+                                <chmod dir="${unpack.source.directory}" perm="644">
+                                    <include name="**/*.java"/> <!-- restore permissions lost by replace above -->
+                                </chmod>
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
                     <skipMain>false</skipMain>

--- a/cometd-java-server/src/main/java/org/cometd/server/BayeuxServerImpl.java
+++ b/cometd-java-server/src/main/java/org/cometd/server/BayeuxServerImpl.java
@@ -42,7 +42,7 @@ import org.eclipse.jetty.util.thread.Scheduler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.security.SecureRandom;

--- a/cometd-java-server/src/main/java/org/cometd/server/transport/AbstractHttpTransport.java
+++ b/cometd-java-server/src/main/java/org/cometd/server/transport/AbstractHttpTransport.java
@@ -29,11 +29,11 @@ import org.joda.time.Interval;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.servlet.*;
-import javax.servlet.http.Cookie;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import javax.servlet.http.HttpSession;
+import jakarta.servlet.*;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
 import java.io.IOException;
 import java.io.Writer;
 import java.net.InetSocketAddress;

--- a/cometd-java-server/src/main/java/org/cometd/server/transport/AbstractStreamHttpTransport.java
+++ b/cometd-java-server/src/main/java/org/cometd/server/transport/AbstractStreamHttpTransport.java
@@ -19,11 +19,11 @@ import org.cometd.bayeux.server.ServerMessage;
 import org.cometd.server.BayeuxServerImpl;
 import org.cometd.server.ServerSessionImpl;
 
-import javax.servlet.AsyncContext;
-import javax.servlet.ServletException;
-import javax.servlet.ServletOutputStream;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.AsyncContext;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.text.ParseException;
 import java.util.ArrayList;

--- a/cometd-java-server/src/main/java/org/cometd/server/transport/AsyncJSONTransport.java
+++ b/cometd-java-server/src/main/java/org/cometd/server/transport/AsyncJSONTransport.java
@@ -20,9 +20,9 @@ import org.cometd.server.BayeuxServerImpl;
 import org.cometd.server.ServerSessionImpl;
 import org.eclipse.jetty.util.Utf8StringBuilder;
 
-import javax.servlet.*;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.*;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.text.ParseException;

--- a/cometd-java-server/src/main/java/org/cometd/server/transport/JSONPTransport.java
+++ b/cometd-java-server/src/main/java/org/cometd/server/transport/JSONPTransport.java
@@ -18,9 +18,9 @@ package org.cometd.server.transport;
 import org.cometd.bayeux.server.ServerMessage;
 import org.cometd.server.BayeuxServerImpl;
 
-import javax.servlet.ServletOutputStream;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.text.ParseException;
 import java.util.regex.Pattern;

--- a/cometd-java-server/src/main/java/org/cometd/server/transport/JSONTransport.java
+++ b/cometd-java-server/src/main/java/org/cometd/server/transport/JSONTransport.java
@@ -18,9 +18,9 @@ package org.cometd.server.transport;
 import org.cometd.bayeux.server.ServerMessage;
 import org.cometd.server.BayeuxServerImpl;
 
-import javax.servlet.ServletOutputStream;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.text.ParseException;
 

--- a/cometd-java-server/src/test/java/org/cometd/server/ServerSessionImplTest.java
+++ b/cometd-java-server/src/test/java/org/cometd/server/ServerSessionImplTest.java
@@ -14,11 +14,11 @@ import org.springframework.core.io.DefaultResourceLoader;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 
-import javax.servlet.*;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletRequestWrapper;
-import javax.servlet.http.HttpServletResponse;
-import javax.servlet.http.HttpServletResponseWrapper;
+import jakarta.servlet.*;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequestWrapper;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletResponseWrapper;
 import java.io.*;
 import java.util.HashMap;
 import java.util.concurrent.TimeUnit;

--- a/cometd-java-websocket-javax-server/pom.xml
+++ b/cometd-java-websocket-javax-server/pom.xml
@@ -12,7 +12,7 @@
     <groupId>com.nsn.cumulocity.dependencies.osgi</groupId>
     <artifactId>cometd-java-websocket-javax-server</artifactId>
     <version>${osgi.cometd.version}</version>
-    <name>Cumulocity :: Dependencies :: Patched :: CometD :: Java WebSocket Server</name>
+    <name>Cumulocity :: Dependencies :: Patched :: CometD :: Java WebSocket Javax Server</name>
     <url>http://startups.jira.com/wiki/display/MTM/Home</url>
 
     <dependencies>
@@ -28,6 +28,10 @@
         <dependency>
             <groupId>jakarta.websocket</groupId>
             <artifactId>jakarta.websocket-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.websocket</groupId>
+            <artifactId>jakarta.websocket-client-api</artifactId>
         </dependency>
     </dependencies>
 
@@ -56,13 +60,38 @@
                 <artifactId>maven-dependency-plugin</artifactId>
                 <configuration>
                     <includeGroupIds>org.cometd.java</includeGroupIds>
-                    <includeArtifactIds>cometd-java-websocket-javax-server</includeArtifactIds>
+                    <includeArtifactIds>cometd-java-websocket-common-server,cometd-java-websocket-javax-server</includeArtifactIds>
                     <excludes>
                         META-INF/MANIFEST.MF,
                         META-INF/maven/**/*,
                         org/cometd/websocket/server/WebSocketTransport.*
                     </excludes>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>replace-javax-to-jakarta</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <replace dir="${unpack.source.directory}">
+                                    <include name="**/*.java"/>
+                                    <replacefilter token="javax.servlet" value="jakarta.servlet" />
+                                    <replacefilter token="javax.websocket" value="jakarta.websocket" />
+                                </replace>
+                                <chmod dir="${unpack.source.directory}" perm="644">
+                                    <include name="**/*.java"/> <!-- restore permissions lost by replace above -->
+                                </chmod>
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/cometd-java-websocket-javax-server/src/main/java/org/cometd/websocket/server/WebSocketTransport.java
+++ b/cometd-java-websocket-javax-server/src/main/java/org/cometd/websocket/server/WebSocketTransport.java
@@ -27,12 +27,12 @@ import org.eclipse.jetty.util.component.LifeCycle;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.servlet.ServletContext;
-import javax.servlet.http.HttpSession;
-import javax.websocket.*;
-import javax.websocket.server.HandshakeRequest;
-import javax.websocket.server.ServerContainer;
-import javax.websocket.server.ServerEndpointConfig;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.http.HttpSession;
+import jakarta.websocket.*;
+import jakarta.websocket.server.HandshakeRequest;
+import jakarta.websocket.server.ServerContainer;
+import jakarta.websocket.server.ServerEndpointConfig;
 import java.net.InetSocketAddress;
 import java.net.SocketTimeoutException;
 import java.util.Collections;

--- a/olingo-odata2-api/pom.xml
+++ b/olingo-odata2-api/pom.xml
@@ -45,13 +45,6 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <skipMain>false</skipMain>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <configuration>
                     <includeGroupIds>org.apache.olingo</includeGroupIds>
@@ -61,6 +54,38 @@
                         META-INF/maven/**/*,
                         org/apache/olingo/odata2/api/uri/expression/MethodOperator.*
                     </excludes>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>replace-javax-to-jakarta</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <replace dir="${unpack.source.directory}">
+                                    <include name="**/*.java"/>
+                                    <replacefilter token="javax.servlet" value="jakarta.servlet" />
+                                    <replacefilter token="javax.websocket" value="jakarta.websocket" />
+                                </replace>
+                                <chmod dir="${unpack.source.directory}" perm="644">
+                                    <include name="**/*.java"/> <!-- restore permissions lost by replace above -->
+                                </chmod>
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <skipMain>false</skipMain>
                 </configuration>
             </plugin>
         </plugins>

--- a/olingo-odata2-core/pom.xml
+++ b/olingo-odata2-core/pom.xml
@@ -65,13 +65,6 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <skipMain>false</skipMain>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <configuration>
                     <includeGroupIds>org.apache.olingo</includeGroupIds>
@@ -82,6 +75,39 @@
                         org/apache/olingo/odata2/core/uri/expression/Tokenizer.*,
                         org/apache/olingo/odata2/core/uri/expression/FilterParserImpl.*
                     </excludes>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>replace-javax-to-jakarta</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <replace dir="${unpack.source.directory}">
+                                    <include name="**/*.java"/>
+                                    <replacefilter token="javax.ws.rs" value="jakarta.ws.rs" />
+                                    <replacefilter token="javax.servlet" value="jakarta.servlet" />
+                                    <replacefilter token="javax.websocket" value="jakarta.websocket" />
+                                </replace>
+                                <chmod dir="${unpack.source.directory}" perm="644">
+                                    <include name="**/*.java"/> <!-- restore permissions lost by replace above -->
+                                </chmod>
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <skipMain>false</skipMain>
                 </configuration>
             </plugin>
         </plugins>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -57,6 +57,7 @@
                                         <exclude>org.apache.olingo:olingo-odata2-api</exclude> <!-- use: com.nsn.cumulocity.dependencies.osgi:olingo-odata2-api -->
                                         <exclude>org.apache.olingo:olingo-odata2-core</exclude> <!-- use: com.nsn.cumulocity.dependencies.osgi:olingo-odata2-core -->
                                         <exclude>org.apache.pulsar:pulsar-client-original</exclude> <!-- use: com.nsn.cumulocity.dependencies.osgi:pulsar-client-original -->
+                                        <exclude>org.bouncycastle:*-jdk15on</exclude> <!-- use: org.bouncycastle:*-jdk18on -->
                                         <exclude>org.cometd.java:cometd-java-server</exclude> <!-- use: com.nsn.cumulocity.dependencies.osgi:cometd-java-server -->
                                         <exclude>org.cometd.java:cometd-java-websocket-javax-server</exclude> <!-- use: com.nsn.cumulocity.dependencies.osgi:cometd-java-websocket-javax-server -->
                                     </excludes>

--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,7 @@
         <module>kubernetes-client</module>
         <module>olingo-odata2-api</module>
         <module>olingo-odata2-core</module>
+        <module>pulsar-client-admin-original</module>
         <module>pulsar-client-original</module>
         <module>svenson</module>
     </modules>
@@ -59,6 +60,7 @@
         <guava.version>33.5.0-jre</guava.version>
         <hk2.version>2.6.1</hk2.version> <!-- pulsar-client.version bound -->
         <javassist.version>3.30.2-GA</javassist.version>
+        <jersey.version>3.0.18</jersey.version>
         <jetty.version>11.0.26</jetty.version>
         <joda-time.version>2.14.1</joda-time.version>
         <json-path.version>2.8.0</json-path.version>
@@ -71,6 +73,7 @@
         <pulsar-client.version>2.8.4</pulsar-client.version>
         <slf4j.version>1.7.36</slf4j.version>
         <snakeyaml.version>1.33</snakeyaml.version> <!-- cxf.version bound -->
+        <sun-activation.version>1.2.2</sun-activation.version>
         <sundr.version>0.200.4</sundr.version> <!-- kubernetes-client.version bound -->
         <svenson.version>1.6.1</svenson.version>
 
@@ -145,6 +148,11 @@
                 <groupId>com.squareup.okhttp3</groupId>
                 <artifactId>logging-interceptor</artifactId>
                 <version>${okhttp.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.sun.activation</groupId>
+                <artifactId>jakarta.activation</artifactId>
+                <version>${sun-activation.version}</version>
             </dependency>
             <dependency>
                 <groupId>commons-beanutils</groupId>
@@ -274,6 +282,23 @@
                 <artifactId>bouncy-castle-bc</artifactId>
                 <version>${pulsar-client.version}</version>
                 <classifier>pkg</classifier>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.bouncycastle</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.pulsar</groupId>
+                <artifactId>bouncy-castle-bc</artifactId>
+                <version>${pulsar-client.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.bouncycastle</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.apache.pulsar</groupId>
@@ -306,6 +331,10 @@
                 <artifactId>pulsar-client-admin-original</artifactId>
                 <version>${pulsar-client.version}</version>
                 <exclusions>
+                    <exclusion>
+                        <groupId>com.sun.activation</groupId>
+                        <artifactId>javax.activation</artifactId>
+                    </exclusion>
                     <exclusion>
                         <groupId>javax.xml.bind</groupId>
                         <artifactId>jaxb-api</artifactId>
@@ -387,6 +416,11 @@
                 <groupId>com.nsn.cumulocity.dependencies.osgi</groupId>
                 <artifactId>olingo-odata2-core</artifactId>
                 <version>${osgi.odata.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.nsn.cumulocity.dependencies.osgi</groupId>
+                <artifactId>pulsar-client-admin-original</artifactId>
+                <version>${osgi.pulsar-client.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.nsn.cumulocity.dependencies.osgi</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.7.18</version>
+        <version>3.0.13</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -58,22 +58,19 @@
         <gson.version>2.12.1</gson.version>
         <guava.version>33.5.0-jre</guava.version>
         <hk2.version>2.6.1</hk2.version> <!-- pulsar-client.version bound -->
-        <jackson-bom.version>2.14.1</jackson-bom.version> <!-- cxf.version bound -->
         <javassist.version>3.30.2-GA</javassist.version>
-        <jetty.version>10.0.26</jetty.version>
+        <jetty.version>11.0.26</jetty.version>
         <joda-time.version>2.14.1</joda-time.version>
         <json-path.version>2.8.0</json-path.version>
         <kubernetes-client.version>7.3.1</kubernetes-client.version>
+        <logback.version>1.2.13</logback.version> <!-- slf4j.version bound -->
         <netty.version>4.1.121.Final</netty.version>
         <odata.version>2.0.13</odata.version>
         <okhttp.version>3.12.12</okhttp.version>
         <protobuf.version>4.34.0</protobuf.version>
         <pulsar-client.version>2.8.4</pulsar-client.version>
-        <rs-api.version>2.1.6</rs-api.version>
-        <servlet-api.version>3.1.0</servlet-api.version>
         <slf4j.version>1.7.36</slf4j.version>
         <snakeyaml.version>1.33</snakeyaml.version> <!-- cxf.version bound -->
-        <spring-framework.version>5.3.39</spring-framework.version>
         <sundr.version>0.200.4</sundr.version> <!-- kubernetes-client.version bound -->
         <svenson.version>1.6.1</svenson.version>
 

--- a/pulsar-client-admin-original/pom.xml
+++ b/pulsar-client-admin-original/pom.xml
@@ -1,0 +1,159 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.nsn.cumulocity.dependencies</groupId>
+        <artifactId>parent</artifactId>
+        <version>${revision}${changelist}</version>
+        <relativePath>../parent</relativePath>
+    </parent>
+
+    <groupId>com.nsn.cumulocity.dependencies.osgi</groupId>
+    <artifactId>pulsar-client-admin-original</artifactId>
+    <version>${osgi.pulsar-client.version}</version>
+    <name>Cumulocity :: Dependencies :: Patched :: Pulsar Client Admin Original</name>
+    <description>
+        This is a re-package of org.apache.pulsar:pulsar-client-admin-original,
+        to migrate from javax to jakarta APIs.
+    </description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.pulsar</groupId>
+            <artifactId>pulsar-client-admin-original</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.nsn.cumulocity.dependencies.osgi</groupId>
+            <artifactId>pulsar-client-original</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.pulsar</groupId>
+            <artifactId>pulsar-client-admin-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.core</groupId>
+            <artifactId>jersey-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.media</groupId>
+            <artifactId>jersey-media-json-jackson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.activation</groupId>
+            <artifactId>jakarta.activation-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.activation</groupId>
+            <artifactId>jakarta.activation</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.media</groupId>
+            <artifactId>jersey-media-multipart</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.jaxrs</groupId>
+            <artifactId>jackson-jaxrs-json-provider</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.inject</groupId>
+            <artifactId>jersey-hk2</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jul-to-slf4j</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.pulsar</groupId>
+            <artifactId>pulsar-package-core</artifactId>
+            <version>${pulsar-client.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>add-sources</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>src/main/java</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <skipMain>false</skipMain>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <configuration>
+                    <includeGroupIds>org.apache.pulsar</includeGroupIds>
+                    <includeArtifactIds>pulsar-client-admin-original</includeArtifactIds>
+                    <excludes>
+                        findbugsExclude.xml,
+                        META-INF/MANIFEST.MF,
+                        META-INF/maven/**/*
+                    </excludes>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>replace-javax-to-jakarta</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <replace dir="${unpack.source.directory}">
+                                    <include name="**/*.java"/>
+                                    <replacefilter token="javax.ws.rs" value="jakarta.ws.rs" />
+                                </replace>
+                                <chmod dir="${unpack.source.directory}" perm="644">
+                                    <include name="**/*.java"/> <!-- restore permissions lost by replace above -->
+                                </chmod>
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/pulsar-client-original/pom.xml
+++ b/pulsar-client-original/pom.xml
@@ -43,6 +43,16 @@
             <classifier>pkg</classifier>
         </dependency>
         <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcpkix-jdk18on</artifactId>
+            <version>${bouncycastle.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-ext-jdk18on</artifactId>
+            <version>${bouncycastle.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.pulsar</groupId>
             <artifactId>pulsar-client-messagecrypto-bc</artifactId>
             <optional>true</optional>
@@ -120,21 +130,6 @@
         <dependency>
             <groupId>net.jcip</groupId>
             <artifactId>jcip-annotations</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.hk2</groupId>
-            <artifactId>hk2-api</artifactId>
-            <version>${hk2.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.hk2</groupId>
-            <artifactId>hk2-locator</artifactId>
-            <version>${hk2.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.hk2</groupId>
-            <artifactId>hk2-utils</artifactId>
-            <version>${hk2.version}</version>
         </dependency>
         <dependency>
             <groupId>org.javassist</groupId>

--- a/svenson/pom.xml
+++ b/svenson/pom.xml
@@ -29,9 +29,17 @@
                     <groupId>com.esotericsoftware.reflectasm</groupId>
                     <artifactId>reflectasm</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 
+        <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>jcl-over-slf4j</artifactId>
@@ -43,12 +51,6 @@
         <dependency>
             <groupId>commons-beanutils</groupId>
             <artifactId>commons-beanutils</artifactId>
-        </dependency>
-        <!-- required for Java 11, provided by karaf -->
-        <dependency>
-            <groupId>javax.annotation</groupId>
-            <artifactId>javax.annotation-api</artifactId>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/svenson/src/main/java/org/svenson/info/JavaObjectSupport.java
+++ b/svenson/src/main/java/org/svenson/info/JavaObjectSupport.java
@@ -2,7 +2,7 @@ package org.svenson.info;
 
 import org.svenson.*;
 
-import javax.annotation.PostConstruct;
+import jakarta.annotation.PostConstruct;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;


### PR DESCRIPTION
Includes:
 - [[SB3.0] Migrate from javax to jakarta](https://cumulocity.atlassian.net/browse/MTM-65247)
 - [[SB3.0] Migrate Pulsar from javax to jakarta](https://cumulocity.atlassian.net/browse/MTM-65806)
 - [[SB3.0] Migrate to Jetty 11](https://cumulocity.atlassian.net/browse/MTM-65731)
 - [[SB3.0] Migrate to CXF 4](https://cumulocity.atlassian.net/browse/MTM-65791)
 - [[SB3.0] Upgrade to Spring Boot 3.0](https://cumulocity.atlassian.net/browse/MTM-63554)