### PR TITLE
Use com.sun.activation:jakarta.activation instead of com.sun.activation:javax.activation

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -42,6 +42,7 @@
                                 <bannedDependencies>
                                     <excludes>
                                         <exclude>com.google.code.svenson:svenson</exclude> <!-- use: com.nsn.cumulocity.dependencies.osgi:svenson -->
+                                        <exclude>com.sun.activation:javax.activation</exclude> <!-- moved to: com.sun.activation:jakarta.activation -->
                                         <exclude>com.sun.xml.bind:jaxb-impl</exclude> <!-- moved to: org.glassfish.jaxb:jaxb-runtime -->
                                         <exclude>commons-logging:commons-logging</exclude> <!-- in favor of SLF4j -->
                                         <exclude>io.fabric8:kubernetes-client</exclude> <!-- use: com.nsn.cumulocity.dependencies.osgi:kubernetes-client -->

--- a/pulsar-client-original/pom.xml
+++ b/pulsar-client-original/pom.xml
@@ -62,6 +62,16 @@
         <dependency>
             <groupId>org.asynchttpclient</groupId>
             <artifactId>async-http-client</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.sun.activation</groupId>
+                    <artifactId>javax.activation</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.activation</groupId>
+            <artifactId>jakarta.activation</artifactId>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
We currenlty have both:

<img width="707" height="81" alt="Screenshot from 2026-02-26 11-17-11" src="https://github.com/user-attachments/assets/4614f8ae-1bca-4427-ace7-edea1e73be82" />

This removes redundant `com.sun.activation:javax.activation`.