### PR TITLE
MTM-66923: fail pending messages in NoReconnectPulsarProducerImpl.reconnectLater()

### DIFF
--- a/pulsar-client-original/pom.xml
+++ b/pulsar-client-original/pom.xml
@@ -145,6 +145,24 @@
             <artifactId>lombok</artifactId>
             <scope>provided</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>${assertj.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>${mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <dependencyManagement>

--- a/pulsar-client-original/src/main/java/org/apache/pulsar/client/impl/NoReconnectPulsarProducerImpl.java
+++ b/pulsar-client-original/src/main/java/org/apache/pulsar/client/impl/NoReconnectPulsarProducerImpl.java
@@ -2,6 +2,7 @@ package org.apache.pulsar.client.impl;
 
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.impl.conf.ProducerConfigurationData;
 
@@ -13,16 +14,19 @@ import java.util.concurrent.CompletableFuture;
 public class NoReconnectPulsarProducerImpl<T> extends ProducerImpl<T> {
 
     private static final Method closeProducerTasksMethod;
+    private static final Method failPendingMessagesMethod;
 
     static {
-        // FIXME hack!! -- we need to call this private parent method to clear some netty timers
+        // FIXME hack!! -- we need to call these private parent methods to clear some netty timers
         //  (which are also private), otherwise there will be a memory leak
         try {
             closeProducerTasksMethod = ProducerImpl.class.getDeclaredMethod("closeProducerTasks");
+            failPendingMessagesMethod = ProducerImpl.class.getDeclaredMethod("failPendingMessages", ClientCnx.class, PulsarClientException.class);
         } catch (NoSuchMethodException e) {
             throw new RuntimeException(e);
         }
         closeProducerTasksMethod.setAccessible(true);
+        failPendingMessagesMethod.setAccessible(true);
     }
 
     public NoReconnectPulsarProducerImpl(PulsarClientImpl client,
@@ -39,11 +43,32 @@ public class NoReconnectPulsarProducerImpl<T> extends ProducerImpl<T> {
         if (exception != null) {
             log.error("Could not connect producer to the broker: {}", exception.getMessage());
             producerCreatedFuture.completeExceptionally(exception);
+            failPendingMessagesWithFailedState(exception);
             invokeCloseProducerTaskMethod();
-            setState(State.Failed);
             getClient().cleanupProducer(this);
         }
         super.reconnectLater(exception);
+    }
+
+    /**
+     * Fails all pending messages and completes their futures exceptionally; without this call they could hang indefinitely once the timeout is cancelled by the {@code closeProducerTasks} method call.
+     * The {@code failPendingMessages} call must be synchronized according to the documentation, also
+     * state must be set to Failed before invoking {@code failPendingMessages}, otherwise we may have a race condition between adding new messages and failing existing ones.
+     */
+    private synchronized void failPendingMessagesWithFailedState(Throwable exception) {
+        setState(State.Failed);
+        invokeFailPendingMessagesMethod(exception);
+    }
+
+    private void invokeFailPendingMessagesMethod(Throwable exception) {
+        try {
+            PulsarClientException pce = exception instanceof PulsarClientException
+                    ? (PulsarClientException) exception
+                    : new PulsarClientException(exception);
+            failPendingMessagesMethod.invoke(this, null, pce);
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     private void invokeCloseProducerTaskMethod() {

--- a/pulsar-client-original/src/test/java/org/apache/pulsar/client/impl/NoReconnectPulsarProducerImplTest.java
+++ b/pulsar-client-original/src/test/java/org/apache/pulsar/client/impl/NoReconnectPulsarProducerImplTest.java
@@ -1,0 +1,106 @@
+package org.apache.pulsar.client.impl;
+
+import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.api.PulsarClientException.ProducerBusyException;
+import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
+import org.apache.pulsar.client.impl.conf.ProducerConfigurationData;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Clock;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.apache.pulsar.client.api.Schema.BYTES;
+import static org.apache.pulsar.client.impl.HandlerState.State.Connecting;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class NoReconnectPulsarProducerImplTest {
+
+    /**
+     * Core regression test: all futures in {@code pendingMessages} must complete exceptionally
+     * when {@code reconnectLater()} is called.
+     *
+     * <p>Without the fix, {@code closeProducerTasks()} cancels the send-timeout timer without
+     * sweeping the queue — futures are permanently orphaned. With the fix,
+     * {@code failPendingMessagesWithFailedState()} completes them before the timer is cancelled.
+     */
+    @Test
+    void shouldCompleteAllPendingFuturesExceptionallyWhenReconnectLaterCalled() {
+        // Given
+        NoReconnectPulsarProducerImpl<byte[]> producer = createProducer();
+
+        List<CompletableFuture<MessageId>> futures = queueMessages(producer, 50);
+
+        assertThat(futures).allMatch(future -> !future.isDone());
+        assertThat(producer.getPendingQueueSize()).isEqualTo(50);
+
+        // When
+        producer.reconnectLater(new ProducerBusyException("Pulsar issue"));
+
+        // Then
+        assertThat(futures).allSatisfy(future -> Assertions.assertThat(future)
+                .completesExceptionallyWithin(1, TimeUnit.SECONDS)
+                .withThrowableOfType(ExecutionException.class)
+                .withCauseInstanceOf(PulsarClientException.class));
+    }
+
+    // Creates a producer with no real broker connection. grabCnx() is overridden to be a no-op,
+    // and state is set to Connecting so sendAsync() accepts messages into pendingMessages
+    // without attempting to write them to a socket.
+    private NoReconnectPulsarProducerImpl<byte[]> createProducer() {
+        NoReconnectPulsarProducerImpl<byte[]> producer = new NoReconnectPulsarProducerImpl<>(
+                pulsarClient(),
+                "persistent://public/default/test",
+                producerConfig(),
+                completedFuture(null),
+                -1,
+                BYTES,
+                null) {
+            @Override
+            void grabCnx() { /* prevent actual broker connection */ }
+        };
+        producer.setState(Connecting);
+        return producer;
+    }
+
+    private PulsarClientImpl pulsarClient() {
+        MemoryLimitController memoryLimitController = mock(MemoryLimitController.class);
+        when(memoryLimitController.tryReserveMemory(anyLong())).thenReturn(true);
+
+        ClientConfigurationData clientConfig = new ClientConfigurationData();
+        clientConfig.setStatsIntervalSeconds(0); // disable stats recorder
+
+        PulsarClientImpl client = mock(PulsarClientImpl.class);
+        when(client.getConfiguration()).thenReturn(clientConfig);
+        when(client.getMemoryLimitController()).thenReturn(memoryLimitController);
+        when(client.getClientClock()).thenReturn(Clock.systemUTC());
+
+        return client;
+    }
+
+    private ProducerConfigurationData producerConfig() {
+        ProducerConfigurationData producerConfig = new ProducerConfigurationData();
+        producerConfig.setTopicName("persistent://public/default/test");
+        producerConfig.setProducerName("test-producer");
+        producerConfig.setSendTimeoutMs(0);      // disable send-timeout timer
+        producerConfig.setMaxPendingMessages(100);
+        producerConfig.setBatchingEnabled(false);
+        return producerConfig;
+    }
+
+    private List<CompletableFuture<MessageId>> queueMessages(NoReconnectPulsarProducerImpl<byte[]> producer, int count) {
+        return IntStream.range(0, count).mapToObj(i -> producer.sendAsync("msg".getBytes())).toList();
+    }
+}


### PR DESCRIPTION
## Root cause

`NoReconnectPulsarProducerImpl.reconnectLater()` was designed to surface broker connection failures immediately instead of retrying silently. However, it stopped the producer and cancelled the send-timeout timer without completing the pending `sendAsync()` futures — leaving them hanging forever with no way to finish.

## Impact

The circuit breaker (Resilience4j) wraps each publish call with `decorateFuture()`. When in HALF_OPEN state, orphaned futures hold its probe slots indefinitely — preventing it from transitioning to OPEN or CLOSED until the application was restarted.

## Fix

Before stopping the producer from reconnecting and cancelling its send-timeout (`closeProducerTasks`), make sure all pending messages are cleared and marked as failed via `failPendingMessagesWithFailedState`. This ensures all `sendAsync()` futures are eventually completed exceptionally and nothing hangs forever. The producer state is set to `Failed` first to prevent new messages from racing in during the sweep.

## Related

A complementary fix in [cumulocity-core PR #4543](https://github.com/Cumulocity-IoT/cumulocity-core/pull/4543) wraps `sendAsync()` with a decorated future with a timeout at the circuit breaker layer.

## Changes

- `NoReconnectPulsarProducerImpl`: added `failPendingMessagesWithFailedState()`, called in `reconnectLater()` before `closeProducerTasks()`
- Added unit test `NoReconnectPulsarProducerImplTest`