### PR TITLE
MTM-67218: Upgrade pulsar-client to 2.11.0 to enable the use of Pulsar TableViews

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
         <odata.version>2.0.13</odata.version>
         <okhttp.version>3.12.12</okhttp.version> <!-- overridden down -->
         <protobuf.version>4.35.1</protobuf.version>
-        <pulsar-client.version>2.11.0</pulsar-client.version> <!-- overridden down -->
+        <pulsar-client.version>2.11.1</pulsar-client.version> <!-- overridden down -->
         <snakeyaml.version>1.33</snakeyaml.version> <!-- cxf.version bound --> <!-- overridden down -->
         <sun-activation.version>1.2.2</sun-activation.version>
         <sundr.version>0.200.4</sundr.version> <!-- kubernetes-client.version bound -->

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
         <odata.version>2.0.13</odata.version>
         <okhttp.version>3.12.12</okhttp.version> <!-- overridden down -->
         <protobuf.version>4.35.1</protobuf.version>
-        <pulsar-client.version>2.8.4</pulsar-client.version> <!-- overridden down -->
+        <pulsar-client.version>2.11.0</pulsar-client.version> <!-- overridden down -->
         <snakeyaml.version>1.33</snakeyaml.version> <!-- cxf.version bound --> <!-- overridden down -->
         <sun-activation.version>1.2.2</sun-activation.version>
         <sundr.version>0.200.4</sundr.version> <!-- kubernetes-client.version bound -->
@@ -79,6 +79,7 @@
         <versions-maven-plugin.version>2.13.0</versions-maven-plugin.version> <!-- overridden down -->
 
         <!-- PROVIDED DEPENDENCIES -->
+        <checkerframework.version>3.33.0</checkerframework.version>
         <lombok.version>1.18.38</lombok.version> <!-- overridden up -->
 
         <!-- CHILD MODULES VERSIONS -->
@@ -375,6 +376,11 @@
                 <groupId>org.bouncycastle</groupId>
                 <artifactId>bcprov-ext-jdk18on</artifactId>
                 <version>${bouncycastle.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.checkerframework</groupId>
+                <artifactId>checker-qual</artifactId>
+                <version>${checkerframework.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.cometd.java</groupId>

--- a/pulsar-client-original/pom.xml
+++ b/pulsar-client-original/pom.xml
@@ -145,6 +145,11 @@
             <artifactId>lombok</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.checkerframework</groupId>
+            <artifactId>checker-qual</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <dependencyManagement>

--- a/pulsar-client-original/src/main/java/org/apache/pulsar/client/impl/NoReconnectPulsarClientImpl.java
+++ b/pulsar-client-original/src/main/java/org/apache/pulsar/client/impl/NoReconnectPulsarClientImpl.java
@@ -6,6 +6,7 @@ import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
 import org.apache.pulsar.client.impl.conf.ProducerConfigurationData;
 
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 public class NoReconnectPulsarClientImpl extends PulsarClientImpl {
@@ -18,13 +19,15 @@ public class NoReconnectPulsarClientImpl extends PulsarClientImpl {
                                                   ProducerConfigurationData conf,
                                                   Schema<T> schema,
                                                   ProducerInterceptors interceptors,
-                                                  CompletableFuture<Producer<T>> producerCreatedFuture) {
+                                                  CompletableFuture<Producer<T>> producerCreatedFuture,
+                                                  Optional<String> overrideProducerName) {
         return new NoReconnectPulsarProducerImpl<>(NoReconnectPulsarClientImpl.this,
                 topic,
                 conf,
                 producerCreatedFuture,
                 partitionIndex,
                 schema,
-                interceptors);
+                interceptors,
+                overrideProducerName);
     }
 }

--- a/pulsar-client-original/src/main/java/org/apache/pulsar/client/impl/NoReconnectPulsarProducerImpl.java
+++ b/pulsar-client-original/src/main/java/org/apache/pulsar/client/impl/NoReconnectPulsarProducerImpl.java
@@ -7,6 +7,7 @@ import org.apache.pulsar.client.impl.conf.ProducerConfigurationData;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 @Slf4j
@@ -30,8 +31,9 @@ public class NoReconnectPulsarProducerImpl<T> extends ProducerImpl<T> {
                                          ProducerConfigurationData conf,
                                          CompletableFuture<Producer<T>> producerCreatedFuture,
                                          int partitionIndex, Schema<T> schema,
-                                         ProducerInterceptors interceptors) {
-        super(client, topic, conf, producerCreatedFuture, partitionIndex, schema, interceptors);
+                                         ProducerInterceptors interceptors,
+                                         Optional<String> overrideProducerName) {
+        super(client, topic, conf, producerCreatedFuture, partitionIndex, schema, interceptors, overrideProducerName);
     }
 
     @Override


### PR DESCRIPTION
Upgrade pulsar-client to 2.11.0, to enable usage of Pulsar TableViews in Core.
Update custom producer and client constructors to match upstream signatures with new parameters.

Testing:
Built core using local snapshot build (some additional changes are required: FakeProducerBuilder used in testing implements new functions, exclusion of log4j-slf4j-impl in cumulocity-shared-components/messaging/pulsar).
Verify `@reliable-notification` and `@data-broker` functional tests still run.