### PR TITLE
MTM-67218: Revert changes to upgrade to pulsar-client 2.11.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
         <odata.version>2.0.13</odata.version>
         <okhttp.version>3.12.12</okhttp.version> <!-- overridden down -->
         <protobuf.version>4.35.1</protobuf.version>
-        <pulsar-client.version>2.11.1</pulsar-client.version> <!-- overridden down -->
+        <pulsar-client.version>2.8.4</pulsar-client.version> <!-- overridden down -->
         <snakeyaml.version>1.33</snakeyaml.version> <!-- cxf.version bound --> <!-- overridden down -->
         <sun-activation.version>1.2.2</sun-activation.version>
         <sundr.version>0.200.4</sundr.version> <!-- kubernetes-client.version bound -->
@@ -79,7 +79,6 @@
         <versions-maven-plugin.version>2.13.0</versions-maven-plugin.version> <!-- overridden down -->
 
         <!-- PROVIDED DEPENDENCIES -->
-        <checkerframework.version>3.33.0</checkerframework.version>
         <lombok.version>1.18.38</lombok.version> <!-- overridden up -->
 
         <!-- CHILD MODULES VERSIONS -->
@@ -371,11 +370,6 @@
                 <groupId>org.bouncycastle</groupId>
                 <artifactId>bcprov-jdk18on</artifactId>
                 <version>${bouncycastle.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.checkerframework</groupId>
-                <artifactId>checker-qual</artifactId>
-                <version>${checkerframework.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.cometd.java</groupId>

--- a/pulsar-client-original/pom.xml
+++ b/pulsar-client-original/pom.xml
@@ -145,11 +145,6 @@
             <artifactId>lombok</artifactId>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>org.checkerframework</groupId>
-            <artifactId>checker-qual</artifactId>
-            <scope>provided</scope>
-        </dependency>
     </dependencies>
 
     <dependencyManagement>

--- a/pulsar-client-original/src/main/java/org/apache/pulsar/client/impl/NoReconnectPulsarClientImpl.java
+++ b/pulsar-client-original/src/main/java/org/apache/pulsar/client/impl/NoReconnectPulsarClientImpl.java
@@ -6,7 +6,6 @@ import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
 import org.apache.pulsar.client.impl.conf.ProducerConfigurationData;
 
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 public class NoReconnectPulsarClientImpl extends PulsarClientImpl {
@@ -19,15 +18,13 @@ public class NoReconnectPulsarClientImpl extends PulsarClientImpl {
                                                   ProducerConfigurationData conf,
                                                   Schema<T> schema,
                                                   ProducerInterceptors interceptors,
-                                                  CompletableFuture<Producer<T>> producerCreatedFuture,
-                                                  Optional<String> overrideProducerName) {
+                                                  CompletableFuture<Producer<T>> producerCreatedFuture) {
         return new NoReconnectPulsarProducerImpl<>(NoReconnectPulsarClientImpl.this,
                 topic,
                 conf,
                 producerCreatedFuture,
                 partitionIndex,
                 schema,
-                interceptors,
-                overrideProducerName);
+                interceptors);
     }
 }

--- a/pulsar-client-original/src/main/java/org/apache/pulsar/client/impl/NoReconnectPulsarProducerImpl.java
+++ b/pulsar-client-original/src/main/java/org/apache/pulsar/client/impl/NoReconnectPulsarProducerImpl.java
@@ -7,7 +7,6 @@ import org.apache.pulsar.client.impl.conf.ProducerConfigurationData;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 @Slf4j
@@ -31,9 +30,8 @@ public class NoReconnectPulsarProducerImpl<T> extends ProducerImpl<T> {
                                          ProducerConfigurationData conf,
                                          CompletableFuture<Producer<T>> producerCreatedFuture,
                                          int partitionIndex, Schema<T> schema,
-                                         ProducerInterceptors interceptors,
-                                         Optional<String> overrideProducerName) {
-        super(client, topic, conf, producerCreatedFuture, partitionIndex, schema, interceptors, overrideProducerName);
+                                         ProducerInterceptors interceptors) {
+        super(client, topic, conf, producerCreatedFuture, partitionIndex, schema, interceptors);
     }
 
     @Override


### PR DESCRIPTION
Revert pulsar-client to 2.8.4. Upgrade pulled in changes which caused a regression to Notifications 2.0 which was shown in Cumulocity postmerge.

Reverting the changes so that future releases of dependencies will not include the regression, while the cause is investigated.