### PR TITLE
MTM-67218: Upgrade pulsar-client to 2.10.4, set memory limit to 0 (be…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,7 @@
         <aircompressor.version>2.0.3</aircompressor.version>
         <avro.version>1.12.1</avro.version>
         <bouncycastle.version>1.85</bouncycastle.version>
+        <checker-qual.version>3.49.2</checker-qual.version> <!-- pulsar-client.version bound -->
         <cometd.version>3.0.10</cometd.version>
         <commons-beanutils.version>1.11.0</commons-beanutils.version>
         <commons-codec.version>1.18.0</commons-codec.version>
@@ -71,7 +72,7 @@
         <odata.version>2.0.13</odata.version>
         <okhttp.version>3.12.12</okhttp.version> <!-- overridden down -->
         <protobuf.version>4.35.1</protobuf.version>
-        <pulsar-client.version>2.8.4</pulsar-client.version> <!-- overridden down -->
+        <pulsar-client.version>2.10.4</pulsar-client.version> <!-- overridden down -->
         <snakeyaml.version>1.33</snakeyaml.version> <!-- cxf.version bound --> <!-- overridden down -->
         <sun-activation.version>1.2.2</sun-activation.version>
         <sundr.version>0.200.4</sundr.version> <!-- kubernetes-client.version bound -->

--- a/pulsar-client-original/pom.xml
+++ b/pulsar-client-original/pom.xml
@@ -132,6 +132,11 @@
             <artifactId>jcip-annotations</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.checkerframework</groupId>
+            <artifactId>checker-qual</artifactId>
+            <version>${checker-qual.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.javassist</groupId>
             <artifactId>javassist</artifactId>
         </dependency>
@@ -144,6 +149,16 @@
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/pulsar-client-original/src/main/java/org/apache/pulsar/client/impl/NoReconnectPulsarClientBuilder.java
+++ b/pulsar-client-original/src/main/java/org/apache/pulsar/client/impl/NoReconnectPulsarClientBuilder.java
@@ -23,6 +23,10 @@ public class NoReconnectPulsarClientBuilder extends ClientBuilderImpl {
         // NOTE: the method's implementation is the same as in superclass,
         // except client object that is being built is of class NoReconnectPulsarClientImpl
 
+        // Restore pulsar-client 2.8.4's disabled (0) client-side memory limit: 2.10.x defaults
+        // this to 64 MiB enabled
+        this.memoryLimit(0, SizeUnit.BYTES);
+
         if (StringUtils.isBlank(conf.getServiceUrl()) && conf.getServiceUrlProvider() == null) {
             throw new IllegalArgumentException("service URL or service URL provider needs to be specified on the ClientBuilder object.");
         }

--- a/pulsar-client-original/src/main/java/org/apache/pulsar/client/impl/NoReconnectPulsarClientImpl.java
+++ b/pulsar-client-original/src/main/java/org/apache/pulsar/client/impl/NoReconnectPulsarClientImpl.java
@@ -6,6 +6,7 @@ import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
 import org.apache.pulsar.client.impl.conf.ProducerConfigurationData;
 
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 public class NoReconnectPulsarClientImpl extends PulsarClientImpl {
@@ -14,17 +15,20 @@ public class NoReconnectPulsarClientImpl extends PulsarClientImpl {
         super(conf);
     }
 
+    @Override
     protected <T> ProducerImpl<T> newProducerImpl(String topic, int partitionIndex,
                                                   ProducerConfigurationData conf,
                                                   Schema<T> schema,
                                                   ProducerInterceptors interceptors,
-                                                  CompletableFuture<Producer<T>> producerCreatedFuture) {
+                                                  CompletableFuture<Producer<T>> producerCreatedFuture,
+                                                  Optional<String> overrideProducerName) {
         return new NoReconnectPulsarProducerImpl<>(NoReconnectPulsarClientImpl.this,
                 topic,
                 conf,
                 producerCreatedFuture,
                 partitionIndex,
                 schema,
-                interceptors);
+                interceptors,
+                overrideProducerName);
     }
 }

--- a/pulsar-client-original/src/main/java/org/apache/pulsar/client/impl/NoReconnectPulsarProducerImpl.java
+++ b/pulsar-client-original/src/main/java/org/apache/pulsar/client/impl/NoReconnectPulsarProducerImpl.java
@@ -7,6 +7,7 @@ import org.apache.pulsar.client.impl.conf.ProducerConfigurationData;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 @Slf4j
@@ -30,8 +31,9 @@ public class NoReconnectPulsarProducerImpl<T> extends ProducerImpl<T> {
                                          ProducerConfigurationData conf,
                                          CompletableFuture<Producer<T>> producerCreatedFuture,
                                          int partitionIndex, Schema<T> schema,
-                                         ProducerInterceptors interceptors) {
-        super(client, topic, conf, producerCreatedFuture, partitionIndex, schema, interceptors);
+                                         ProducerInterceptors interceptors,
+                                         Optional<String> overrideProducerName) {
+        super(client, topic, conf, producerCreatedFuture, partitionIndex, schema, interceptors, overrideProducerName);
     }
 
     @Override

--- a/pulsar-client-original/src/test/java/org/apache/pulsar/client/impl/NoReconnectPulsarClientBuilderTest.java
+++ b/pulsar-client-original/src/test/java/org/apache/pulsar/client/impl/NoReconnectPulsarClientBuilderTest.java
@@ -1,0 +1,23 @@
+package org.apache.pulsar.client.impl;
+
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class NoReconnectPulsarClientBuilderTest {
+
+    @Test
+    public void buildDisablesClientSideMemoryLimit() throws PulsarClientException {
+        NoReconnectPulsarClientBuilder builder = NoReconnectPulsarClientBuilder.noReconnectPulsarClientBuilder();
+        builder.serviceUrl("pulsar://localhost:6650");
+
+        PulsarClient client = builder.build();
+        try {
+            assertThat(builder.conf.getMemoryLimitBytes()).isZero();
+        } finally {
+            client.close();
+        }
+    }
+}


### PR DESCRIPTION
Follow up from https://github.com/Cumulocity-IoT/cumulocity-dependencies/pull/251.
Version 2.11.0 introduced a correctness bug which was not resolved until 2.11.3 (https://github.com/apache/pulsar/pull/19191) which cannot be used with the no reconnect customisations.

2.10.4 was selected as the next upgrade candidate as:

- Works with current no reconnect customisations
- Includes TableView API
- Avoids regression behaviour introduced in 2.11.0

Tested local (functional tests with tags `@reliablenotifications` and `@data-broker`. And with core pre-merge job, devx environment seems to be configured with smaller maximum message size so the test fails at smaller sizes than expected but the behaviour is correct (rejection due to size instead of timeout).