### PR TITLE
dependabot: ignore JUnit versions >=6.0.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,3 +38,5 @@ updates:
         versions: [ ">=7.0.0" ]
       - dependency-name: "org.springframework.boot:*"
         versions: [ ">=4.0.0" ]
+      - dependency-name: "org.junit:*"
+        versions: [ ">=6.0.0" ]


### PR DESCRIPTION
It would be better to update `org.junit:junit-bom` to `5.14` first since it has `Deprecations along with new APIs to ease migration to JUnit 6`, see: https://docs.junit.org/5.14.0/release-notes/