### PR TITLE
MTM-67218: Add missing netty-reactive-streams to pulsar-client-original

### DIFF
--- a/pulsar-client-original/pom.xml
+++ b/pulsar-client-original/pom.xml
@@ -64,6 +64,10 @@
             <artifactId>async-http-client</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.typesafe.netty</groupId>
+            <artifactId>netty-reactive-streams</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>


### PR DESCRIPTION
## Why

Upstream Pulsar declares `com.typesafe.netty:netty-reactive-streams` in the client module we repackage:
https://github.com/apache/pulsar/blob/branch-2.10/pulsar-client/pom.xml#L99

So `pulsar-client-original` needs it too. No explicit version — the `org.apache.pulsar:pulsar` pom we import in `dependencyManagement` already manages it, so we stay on the version Pulsar itself pins (2.0.6).

## Impact

async-http-client 2.12.1 needs the class at runtime. `AsyncHttpClientHandler.channelReadComplete()` evaluates

```java
Channels.getAttribute(ctx.channel()) instanceof StreamedResponsePublisher
```

which cannot be resolved without the jar (`StreamedResponsePublisher extends com.typesafe.netty.HandlerPublisher`). The resulting `ClassNotFoundException` is only logged at DEBUG, as an "Unexpected I/O exception", and the channel is closed with `DISCARD` without completing the response future.

That check guards the `ctx.read()` in the same method, and async-http-client runs with netty `AUTO_READ` disabled — so `ctx.read()` is the only thing that pulls the next chunk:

- response fits netty's 2048 byte initial receive buffer → already complete, request succeeds
- response is larger → rest of the body never requested, future never completed, caller blocks until the read timeout

This is the root cause of the `PulsarAdmin` timeouts behind L2S-1891, which led to the revert of cumulocity-core#4699. `tenants().getTenants()` broke on environments with enough tenants to push the response past 2048 bytes, while smaller calls such as `namespaces().getNamespaces(...)` kept working — which is why it looked environment-specific.

## Verification

`mvn dependency:tree` on the module after the change:

```
+- org.asynchttpclient:async-http-client:jar:2.12.1:compile
+- com.typesafe.netty:netty-reactive-streams:jar:2.0.6:compile
```

Reproduced and fixed against a mock broker; regression test added in the paired [core PR](https://github.com/Cumulocity-IoT/cumulocity-core/pull/4749) (`PulsarAdminLargeResponseTest`), which fails with a `TimeoutException` without this dependency and passes with it.

Related:
* https://github.com/Cumulocity-IoT/cumulocity-core/pull/4749

🤖 Generated with [Claude Code](https://claude.com/claude-code)
