### PR TITLE
MTM-67218: Add missing netty-reactive-streams to pulsar-client-original

### DIFF
--- a/pulsar-client-original/pom.xml
+++ b/pulsar-client-original/pom.xml
@@ -77,6 +77,11 @@
                     <groupId>com.sun.activation</groupId>
                     <artifactId>javax.activation</artifactId>
                 </exclusion>
+                <!-- declared below, on the version managed by the imported pulsar pom -->
+                <exclusion>
+                    <groupId>com.typesafe.netty</groupId>
+                    <artifactId>netty-reactive-streams</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/pulsar-client-original/pom.xml
+++ b/pulsar-client-original/pom.xml
@@ -84,6 +84,10 @@
             <artifactId>jakarta.activation</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.typesafe.netty</groupId>
+            <artifactId>netty-reactive-streams</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>


### PR DESCRIPTION
Develop counterpart of #271 (release/y2026).

## Why

Upstream Pulsar declares `com.typesafe.netty:netty-reactive-streams` in the client module we repackage:
https://github.com/apache/pulsar/blob/branch-2.10/pulsar-client/pom.xml#L99

So `pulsar-client-original` needs it too. No explicit version — the `org.apache.pulsar:pulsar` pom we import in `dependencyManagement` already manages it, so we stay on the version Pulsar itself pins (2.0.6).

On develop the jar is currently on the classpath only by accident: our own `<exclusions>` block on `async-http-client` replaces the exclusions managed by the imported pulsar pom instead of merging with them, so async-http-client's own transitive copy survives (2.0.4). That is fragile — removing or reworking that unrelated exclusion silently drops the dependency again.

This change declares it explicitly, on the version Pulsar pins:

```
before:  \- com.typesafe.netty:netty-reactive-streams:jar:2.0.4:compile   (child of async-http-client)
after:   +- com.typesafe.netty:netty-reactive-streams:jar:2.0.6:compile   (direct)
```

The second commit adds `com.typesafe.netty:netty-reactive-streams` to the `async-http-client` exclusions block, restoring what the pulsar pom intended. Without it both versions sit on the graph at once and the `DependencyConvergence` enforcer rule fails:

```
Dependency convergence error for com.typesafe.netty:netty-reactive-streams:jar:2.0.4
  ...pulsar-client-original -> async-http-client -> netty-reactive-streams:2.0.4
and
  ...pulsar-client-original -> netty-reactive-streams:2.0.6
```

release/y2026 (#271) does not need that second commit — its `async-http-client` declaration carries no `<exclusions>`, so the managed exclusions apply and 2.0.6 is the only version on the graph.


## Impact if it is missing

async-http-client 2.12.1 needs the class at runtime. `AsyncHttpClientHandler.channelReadComplete()` evaluates

```java
Channels.getAttribute(ctx.channel()) instanceof StreamedResponsePublisher
```

which cannot be resolved without the jar (`StreamedResponsePublisher extends com.typesafe.netty.HandlerPublisher`). The resulting `ClassNotFoundException` is only logged at DEBUG, as an "Unexpected I/O exception", and the channel is closed with `DISCARD` without completing the response future.

That check guards the `ctx.read()` in the same method, and async-http-client runs with netty `AUTO_READ` disabled — so `ctx.read()` is the only thing that pulls the next chunk:

- response fits netty's 2048 byte initial receive buffer → already complete, request succeeds
- response is larger → rest of the body never requested, future never completed, caller blocks until the read timeout

That is what happened on release/y2026, where the exclusion did apply: `PulsarAdmin.tenants().getTenants()` timed out on environments with enough tenants to push the response past 2048 bytes (L2S-1891, which led to the revert of cumulocity-core#4699).

## Verification

`mvn dependency:tree` on the module after the change:

```
+- org.asynchttpclient:async-http-client:jar:2.12.1:compile
+- com.typesafe.netty:netty-reactive-streams:jar:2.0.6:compile
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

